### PR TITLE
Making shutdown timeout of httpkit configurable

### DIFF
--- a/src/de/otto/tesla/serving_with_httpkit.clj
+++ b/src/de/otto/tesla/serving_with_httpkit.clj
@@ -34,9 +34,12 @@
       (assoc self :httpkit server)))
 
   (stop [self]
-    (log/info "<- stopping httpkit")
-    (when-let [server (:httpkit self)]
-      (server))
+    (let [timeout (get-in config [:config :httpkit-timeout] 100)]
+      (if-let [server (:httpkit self)]
+        (do 
+          (log/info "<- stopping httpkit with timeout:" timeout "ms")
+          (server :timeout timeout))
+        (log/info "<- stopping httpkit")))
     self))
 
 (defn new-server [] (map->HttpkitServer {}))


### PR DESCRIPTION
If a tesla-httpkit component is stopped, it shuts down httpkit with the standard timeout of 100ms. This pull request makes the timeout configurable by setting the :httpkit-timeout in the tesla config component.
